### PR TITLE
Fix broken login test

### DIFF
--- a/auth/src/test/scala/com/clovellytech/auth/infrastructure/endpoint/AuthEndpointsTestSpec.scala
+++ b/auth/src/test/scala/com/clovellytech/auth/infrastructure/endpoint/AuthEndpointsTestSpec.scala
@@ -20,7 +20,7 @@ class AuthEndpointsTestSpec extends FunSuite with IOTest with Matchers{
     endpoints.loginUser(user).map{
       r =>
         r.status should equal (Status.Ok)
-        r.cookies should not be empty
+        r.headers.map(_.name.toString) should contain ("Authorization")
     }
   }
 


### PR DESCRIPTION
Login was mistakenly checking cookies instead of the authorization header.