### PR TITLE
Simplify types everywhere with use of some convenient aliases

### DIFF
--- a/auth/src/main/scala/com/clovellytech/auth/db/sql/package.scala
+++ b/auth/src/main/scala/com/clovellytech/auth/db/sql/package.scala
@@ -1,21 +1,14 @@
-package com.clovellytech.auth.db
-
-import java.util.UUID
+package com.clovellytech.auth
+package db
 
 import doobie.Meta
-import tsec.authentication.TSecBearerToken
+
 import tsec.common.SecureRandomId
 import doobie.postgres.implicits._
 
 package object sql {
   object users extends UserSQL
   object tokens extends BearerSQL
-
-  type Instant = java.time.Instant
-  type UserId = UUID
-
-  type BearerToken = TSecBearerToken[UserId]
-  val BearerToken = TSecBearerToken
 
   implicit val userIdMeta = Meta[UserId]
   implicit val instantMeta = Meta[Instant]

--- a/auth/src/main/scala/com/clovellytech/auth/domain/tokens/TokenRepositoryAlgebra.scala
+++ b/auth/src/main/scala/com/clovellytech/auth/domain/tokens/TokenRepositoryAlgebra.scala
@@ -1,7 +1,6 @@
 package com.clovellytech.auth
 package domain.tokens
 
-import com.clovellytech.auth.db.sql.BearerToken
 import com.clovellytech.db.CRUDAlgebra
 import tsec.common.SecureRandomId
 

--- a/auth/src/main/scala/com/clovellytech/auth/domain/tokens/TokenService.scala
+++ b/auth/src/main/scala/com/clovellytech/auth/domain/tokens/TokenService.scala
@@ -1,7 +1,6 @@
 package com.clovellytech.auth
 package domain.tokens
 
-import com.clovellytech.auth.db.sql.BearerToken
 import com.clovellytech.db.CRUDService
 import tsec.common.SecureRandomId
 

--- a/auth/src/main/scala/com/clovellytech/auth/infrastructure/authentication/UserStore.scala
+++ b/auth/src/main/scala/com/clovellytech/auth/infrastructure/authentication/UserStore.scala
@@ -7,12 +7,12 @@ import java.util.UUID
 import cats.Monad
 import cats.data.OptionT
 import cats.implicits._
-import com.clovellytech.auth.db.sql.BearerToken
+import tsec.common.SecureRandomId
+
 import com.clovellytech.auth.domain.tokens.TokenRepositoryAlgebra
 import com.clovellytech.auth.domain.users.UserRepositoryAlgebra
 import tsec.authentication._
 import db.domain._
-import tsec.common.SecureRandomId
 
 trait FunctionKK[X[_[_]], Y[_[_]]] {
   def apply[M[_]: Monad](xa: X[M]) : Y[M]

--- a/auth/src/main/scala/com/clovellytech/auth/infrastructure/endpoint/Auth.scala
+++ b/auth/src/main/scala/com/clovellytech/auth/infrastructure/endpoint/Auth.scala
@@ -1,11 +1,9 @@
 package com.clovellytech.auth
 package infrastructure.endpoint
 
-import java.util.UUID
-
 import scala.concurrent.duration._
 import cats.data.OptionT
-import cats.effect.Effect
+import cats.effect.Sync
 import cats.implicits._
 import io.circe.syntax._
 import org.http4s._
@@ -20,7 +18,7 @@ import domain.users.UserService
 import domain.tokens.TokenService
 import infrastructure.authentication.TransBackingStore._
 
-class AuthEndpoints[F[_]: Effect, A](
+class AuthEndpoints[F[_]: Sync, A](
   userService : UserService[F],
   tokenService : TokenService[F],
   hasher : JCAPasswordPlatform[A]
@@ -67,7 +65,7 @@ extends Http4sDsl[F] {
   }
 
 
-  val authService: TSecAuthService[User, TSecBearerToken[UUID], F] = TSecAuthService {
+  val authService: BearerAuthService[F] = BearerAuthService {
     case GET -> Root / "user" / name asAuthed _ =>
       (for {
         u <- userService.byUsername(name)

--- a/auth/src/main/scala/com/clovellytech/auth/infrastructure/repository/persistent/TokenRepositoryInterpreter.scala
+++ b/auth/src/main/scala/com/clovellytech/auth/infrastructure/repository/persistent/TokenRepositoryInterpreter.scala
@@ -7,8 +7,7 @@ import cats.implicits._
 import doobie._
 import doobie.implicits._
 import domain.tokens.TokenRepositoryAlgebra
-import db.sql.{BearerToken, tokens}
-import tsec.common.SecureRandomId
+import db.sql.tokens
 
 class TokenRepositoryInterpreter[M[_] : Monad](xa : Transactor[M]) extends TokenRepositoryAlgebra[M] {
   def insert(a: BearerToken): M[Unit] = tokens.insert(a).run.as(()).transact(xa)

--- a/auth/src/main/scala/com/clovellytech/auth/package.scala
+++ b/auth/src/main/scala/com/clovellytech/auth/package.scala
@@ -1,0 +1,25 @@
+package com.clovellytech
+
+import java.util.UUID
+
+import cats.Monad
+import com.clovellytech.auth.db.domain.User
+import org.http4s.Response
+import tsec.authentication.{SecuredRequest, TSecAuthService, TSecBearerToken}
+
+package object auth {
+
+  type Instant = java.time.Instant
+  type UserId = UUID
+
+  type SecureRandomId = tsec.common.SecureRandomId
+
+  type BearerToken = TSecBearerToken[UserId]
+  val BearerToken = TSecBearerToken
+
+  type BearerAuthService[F[_]] = TSecAuthService[User, BearerToken, F]
+
+  def BearerAuthService[M[_] : Monad](
+    pf: PartialFunction[SecuredRequest[M, User, BearerToken], M[Response[M]]]
+  ) : BearerAuthService[M] = TSecAuthService(pf)
+}

--- a/auth/src/main/scala/com/clovellytech/auth/testing/AuthTestEndpoints.scala
+++ b/auth/src/main/scala/com/clovellytech/auth/testing/AuthTestEndpoints.scala
@@ -1,21 +1,20 @@
 package com.clovellytech.auth
-package infrastructure
-package endpoint
+package testing
 
 import cats.implicits._
-import cats.effect.Effect
+import cats.effect.Sync
+import com.clovellytech.auth.infrastructure.endpoint.{AuthEndpoints, UserRequest}
 import doobie.util.transactor.Transactor
 import org.http4s._
 import org.http4s.dsl._
 import org.http4s.client.dsl._
 import tsec.passwordhashers.jca.BCrypt
-
 import domain.tokens.TokenService
 import domain.users.UserService
-import repository.persistent.{TokenRepositoryInterpreter, UserRepositoryInterpreter}
+import infrastructure.repository.persistent.{TokenRepositoryInterpreter, UserRepositoryInterpreter}
 
 
-class TestEndpoints[F[_]: Effect](xa: Transactor[F]) extends Http4sDsl[F] with Http4sClientDsl[F] {
+class AuthTestEndpoints[F[_]: Sync](xa: Transactor[F]) extends Http4sDsl[F] with Http4sClientDsl[F] {
   val authEndpoints: AuthEndpoints[F, BCrypt] = {
     val uinterp = new UserRepositoryInterpreter[F](xa)
     val uservice = new UserService[F](uinterp)

--- a/auth/src/test/scala/com/clovellytech/auth/infrastructure/endpoint/AuthEndpointsTestSpec.scala
+++ b/auth/src/test/scala/com/clovellytech/auth/infrastructure/endpoint/AuthEndpointsTestSpec.scala
@@ -1,14 +1,16 @@
 package com.clovellytech.auth.infrastructure
 package endpoint
 
+import org.scalatest._
 
 import cats.effect.IO
 import cats.implicits._
-import org.scalatest._
 import org.http4s.Status
 
+import com.clovellytech.auth.testing.AuthTestEndpoints
+
 class AuthEndpointsTestSpec extends FunSuite with IOTest with Matchers{
-  val endpoints = new TestEndpoints(testTransactor)
+  val endpoints = new AuthTestEndpoints(testTransactor)
 
   val user = UserRequest("zak", "password".getBytes)
 

--- a/features/src/main/scala/com/clovellytech/featurerequests/infrastructure/endpoint/RequestEndpoints.scala
+++ b/features/src/main/scala/com/clovellytech/featurerequests/infrastructure/endpoint/RequestEndpoints.scala
@@ -5,7 +5,7 @@ package infrastructure.endpoint
 import java.time.Instant
 import java.util.UUID
 
-import cats.effect.Effect
+import cats.effect.Sync
 import cats.implicits._
 import com.clovellytech.featurerequests.db.domain.{Feature, FeatureId}
 import domain.requests.{FeatureRequest, RequestService}
@@ -14,9 +14,9 @@ import org.http4s.dsl.Http4sDsl
 
 final case class VotedFeatures(featureId: FeatureId, feature: Feature, dateCreated: Instant, upvotes: Long, downvotes: Long)
 
-class RequestEndpoints[F[_]: Effect] extends Http4sDsl[F] {
-
-  def endpoints(requestService: RequestService[F]) : HttpService[F] = HttpService {
+class RequestEndpoints[F[_]: Sync](requestService: RequestService[F]) extends Http4sDsl[F] {
+  def endpoints
+  : HttpService[F] = HttpService {
     case req @ POST -> Root / "request" => for {
       featureRequest <- req.as[FeatureRequest]
       feature : Feature = Feature(UUID.randomUUID().some, featureRequest.title, featureRequest.description)

--- a/features/src/main/scala/com/clovellytech/featurerequests/infrastructure/endpoint/VoteEndpoints.scala
+++ b/features/src/main/scala/com/clovellytech/featurerequests/infrastructure/endpoint/VoteEndpoints.scala
@@ -1,15 +1,16 @@
 package com.clovellytech.featurerequests
-package infrastructure.endpoint
+package infrastructure
+package endpoint
 
-import cats.effect.Effect
+import cats.effect.Sync
 import cats.implicits._
-import org.http4s.HttpService
 import org.http4s.dsl.Http4sDsl
 import domain.votes.{VoteRequest, VoteService}
+import org.http4s.HttpService
 
-class VoteEndpoints[F[_]: Effect] extends Http4sDsl[F] {
+class VoteEndpoints[F[_]: Sync](voteService: VoteService[F]) extends Http4sDsl[F] {
 
-  def endpoints(voteService: VoteService[F]) : HttpService[F] = HttpService {
+  def endpoints : HttpService[F] = HttpService {
     case req @ POST -> Root / "vote" => for {
       vote <- req.as[VoteRequest]
       resp <- Ok()

--- a/features/src/test/scala/com/clovellytech/featurerequests/IOTest.scala
+++ b/features/src/test/scala/com/clovellytech/featurerequests/IOTest.scala
@@ -1,0 +1,9 @@
+package com.clovellytech.featurerequests
+
+import cats.effect.IO
+import org.scalatest.FunSuite
+
+trait IOTest { this: FunSuite =>
+  def testIO(name: String)(t: => IO[Any]) = test(name)(t.unsafeRunSync())
+}
+

--- a/features/src/test/scala/com/clovellytech/featurerequests/infrastructure/endpoint/RequestEndpointsTestSpec.scala
+++ b/features/src/test/scala/com/clovellytech/featurerequests/infrastructure/endpoint/RequestEndpointsTestSpec.scala
@@ -5,9 +5,7 @@ package endpoint
 import cats.data.OptionT
 import org.scalatest._
 import cats.effect.IO
-import com.clovellytech.auth.infrastructure.endpoint.IOTest
 import domain.requests._
-import db.sql.testTransactor.testTransactor
 import org.http4s.Response
 import db.sql.testTransactor.testTransactor
 


### PR DESCRIPTION
This moves several Auth concerns into the auth package object, so that tsec types need not be imported by users of the auth project.